### PR TITLE
Fix load-file "./esonify-sound-wav.el"

### DIFF
--- a/esonify.el
+++ b/esonify.el
@@ -27,17 +27,20 @@
 
 ;;; Code:
 
+(require 'sound-wav)
+
 (defvar esonify--start-delay 0.4)
 (defvar esonify--read-speed 0.1)
 
 (defconst esonify--el-source-dir
   (file-name-directory (or load-file-name (buffer-file-name))))
 
-(load-file (expand-file-name "./esonify-sound-wav.el" esonify--el-source-dir))
-
 (defconst esonify--soundpath (expand-file-name "./sounds/" esonify--el-source-dir))
 
 (defconst esonify--alphabet-map #s(hash-table size 26 data (122 0 120 1 99 2 118 3 98 4 110 5 109 6 97 7 115 8 100 9 102 10 103 11 104 12 106 13 107 14 108 15 113 16 119 17 101 18 114 19 116 20 121 21 117 22 105 23 111 24 112 25 )))
+
+(defun esonify--sound-wav-play (&rest files)
+  (apply #'sound-wav-play files))
 
 (defun esonify--play-drum(num)
   (esonify--sound-wav-play (concat esonify--soundpath "/drum_" (number-to-string num) ".wav")))


### PR DESCRIPTION
The file is missing in the repository. This patch adds esonify--sound-wav-play defun as a replacement.